### PR TITLE
Migrate from Arche to Ark ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This framework contains inspiration from [Bevy](https://github.com/bevyengine/be
 
 ## Features
 
-- Support for [Arche](https://github.com/mlange-42/arche) ECS
+- Support for [Ark](https://github.com/mlange-42/ark) ECS
 - Support for [Mipix](https://github.com/tinne26/mipix)
 - More coming...

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
-	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
+	"github.com/mlange-42/ark/ecs"
 	"github.com/realskyquest/flybit/v3"
 )
 
@@ -21,8 +20,8 @@ type HelloworldGame struct {
 
 // -- ecs resources --
 var (
-	AppRes  generic.Resource[flybit.App]
-	GameRes generic.Resource[HelloworldGame]
+	AppRes  ecs.Resource[flybit.App]
+	GameRes ecs.Resource[HelloworldGame]
 )
 
 type Game struct {
@@ -64,8 +63,8 @@ func main() {
 }
 
 func loadRes(world *ecs.World) {
-	AppRes = generic.NewResource[flybit.App](world)
-	GameRes = generic.NewResource[HelloworldGame](world)
+	AppRes = ecs.NewResource[flybit.App](world)
+	GameRes = ecs.NewResource[HelloworldGame](world)
 }
 
 func loadFonts(world *ecs.World) {

--- a/examples/signal/main.go
+++ b/examples/signal/main.go
@@ -9,8 +9,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
-	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
+	"github.com/mlange-42/ark/ecs"
 	"github.com/realskyquest/flybit/v3"
 	"github.com/realskyquest/flybit/v3/signal"
 )
@@ -39,8 +38,8 @@ const (
 
 // -- ecs resources --
 var (
-	AppRes  generic.Resource[flybit.App]
-	GameRes generic.Resource[SignalGame]
+	AppRes  ecs.Resource[flybit.App]
+	GameRes ecs.Resource[SignalGame]
 )
 
 type Game struct {
@@ -93,8 +92,8 @@ func main() {
 }
 
 func loadRes(world *ecs.World) {
-	AppRes = generic.NewResource[flybit.App](world)
-	GameRes = generic.NewResource[SignalGame](world)
+	AppRes = ecs.NewResource[flybit.App](world)
+	GameRes = ecs.NewResource[SignalGame](world)
 
 	g := GameRes.Get()
 	g.signals = signal.New()

--- a/examples/state/main.go
+++ b/examples/state/main.go
@@ -9,8 +9,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
-	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
+	"github.com/mlange-42/ark/ecs"
 	"github.com/realskyquest/flybit/v3"
 )
 
@@ -29,8 +28,8 @@ const (
 
 // -- ecs resources --
 var (
-	AppRes  generic.Resource[flybit.App]
-	GameRes generic.Resource[StateGame]
+	AppRes  ecs.Resource[flybit.App]
+	GameRes ecs.Resource[StateGame]
 )
 
 type Game struct {
@@ -75,8 +74,8 @@ func main() {
 }
 
 func loadRes(world *ecs.World) {
-	AppRes = generic.NewResource[flybit.App](world)
-	GameRes = generic.NewResource[StateGame](world)
+	AppRes = ecs.NewResource[flybit.App](world)
+	GameRes = ecs.NewResource[StateGame](world)
 }
 
 func loadFonts(world *ecs.World) {

--- a/examples/substate/main.go
+++ b/examples/substate/main.go
@@ -9,8 +9,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
-	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
+	"github.com/mlange-42/ark/ecs"
 	"github.com/realskyquest/flybit/v3"
 )
 
@@ -39,8 +38,8 @@ const (
 
 // -- ecs resources --
 var (
-	AppRes  generic.Resource[flybit.App]
-	GameRes generic.Resource[StateGame]
+	AppRes  ecs.Resource[flybit.App]
+	GameRes ecs.Resource[StateGame]
 )
 
 type Game struct {
@@ -94,8 +93,8 @@ func main() {
 }
 
 func loadRes(world *ecs.World) {
-	AppRes = generic.NewResource[flybit.App](world)
-	GameRes = generic.NewResource[StateGame](world)
+	AppRes = ecs.NewResource[flybit.App](world)
+	GameRes = ecs.NewResource[StateGame](world)
 
 	a := AppRes.Get()
 	a.SetSubState(BOWL_STATUS, RICE_CRUMBS)

--- a/flybit.go
+++ b/flybit.go
@@ -1,8 +1,7 @@
 package flybit
 
 import (
-	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
+	"github.com/mlange-42/ark/ecs"
 )
 
 // ScheduleLabel defines when a system should be executed in the game loop
@@ -47,12 +46,12 @@ type System struct {
 
 // Game manages the main game loop and system execution
 type Game struct {
-	appRes generic.Resource[App]
+	appRes ecs.Resource[App]
 }
 
 // Load initializes the game and runs LOAD and ON_LOAD systems
 func (g *Game) Load(app *App) {
-	g.appRes = generic.NewResource[App](app.worldPtr)
+	g.appRes = ecs.NewResource[App](app.worldPtr)
 	runScheduleOnce(app, LOAD, ON_LOAD)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/realskyquest/flybit/v3
 
-go 1.23.6
+go 1.24.0
+
+toolchain go1.24.2
 
 require (
 	github.com/hajimehoshi/ebiten/v2 v2.8.6
-	github.com/mlange-42/arche v0.15.3
+	github.com/mlange-42/ark v0.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/hajimehoshi/ebiten/v2 v2.8.6 h1:Dkd/sYI0TYyZRCE7GVxV59XC+WCi2BbGAbIBj
 github.com/hajimehoshi/ebiten/v2 v2.8.6/go.mod h1:cCQ3np7rdmaJa1ZnvslraVlpxNb3wCjEnAP1LHNyXNA=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
-github.com/mlange-42/arche v0.15.3 h1:vonT1aCIHmu3nnCopzmhzOP5+J2NswVTexa2UDyek34=
-github.com/mlange-42/arche v0.15.3/go.mod h1:bX5PDzTbf2pEIlwnjRu3IpVqduLsxve4rUblXV0Byj0=
+github.com/mlange-42/ark v0.4.1 h1:1DDIZ2x5O5+8j2Of+g2UHLyC0CsJLsuukdedi/2ZCqc=
+github.com/mlange-42/ark v0.4.1/go.mod h1:47KXHr5HLftLn4iyL8w04iv7KJUNUoDymEIotD41f3o=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -3,7 +3,7 @@ package signal
 import (
 	"errors"
 
-	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/ark/ecs"
 )
 
 type SignalID uint16

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,6 @@
 package flybit
 
-import "github.com/mlange-42/arche/ecs"
+import "github.com/mlange-42/ark/ecs"
 
 // runScheduleOnce executes systems that match either of the two provided schedule labels
 // and have no run conditions. Systems must either have state 0 (global) or match the app's current state.


### PR DESCRIPTION
[Ark](https://github.com/mlange-42/ark) is the successor of Arche. It has a more consistent API, faster queries, and more feature-rich entity relationships.

Suggesting to migrate from Arche to Ark. However, note that this requires to upgrade to Go 1.24.